### PR TITLE
Fix link from old repo to new org repo.

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,13 +29,13 @@
 
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
- 
+
     <!-- Custom Google Web Font -->
     <link href='http://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
     <link href='http://fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic' rel='stylesheet' type='text/css'>
 	<link href='http://fonts.googleapis.com/css?family=Arvo:400,700' rel='stylesheet' type='text/css'>
 	<link href='http://fonts.googleapis.com/css?family=Muli:400,700' rel='stylesheet' type='text/css'>
-	
+
     <link href="/css/home.css" rel="stylesheet">
     <!--
     <link href="css/general.css" rel="stylesheet">
@@ -63,10 +63,10 @@
 	<div id="preloader">
 		<div id="status"></div>
 	</div>
-	
+
     <div class="intro-header">
 		<div class="col-xs-12 text-center abcen1">
-			<h1 class="h1_home wow fadeIn" data-wow-delay="0.4s"><img src="/images/dapperdox_logo_circle.svg"/>DapperDox</h1> 
+			<h1 class="h1_home wow fadeIn" data-wow-delay="0.4s"><img src="/images/dapperdox_logo_circle.svg"/>DapperDox</h1>
             <h3 class="h3_home wow fadeIn" data-wow-delay="0.6s">Beautiful, integrated, OpenAPI documentation</h3>
 			<ul class="list-inline intro-social-buttons">
                 <li><a href="/docs/getting-started" class="btn  btn-lg mybutton_cyan wow fadeIn" data-wow-delay="0.8s"><span class="network-name">Get Started</span></a>
@@ -74,9 +74,9 @@
 				<li id="download" ><a href="/download/downloads" class="btn  btn-lg mybutton_cyan wow swing wow fadeIn" data-wow-delay="1.2s"><span class="network-name">Download</span></a>
 				</li>
 			</ul>
-		</div>    
+		</div>
     </div>
-	
+
 	<!-- Why DapperDox -->
 	<div id="whatis" class="content-section-b" style="border-top: 0">
 		<div class="container">
@@ -88,7 +88,7 @@
                 guides and diagrams.</p>
 			</div>
 			</div>
-			
+
 			<div class="row">
 				<div class="col-sm-4 wow fadeInDown text-center">
 				  <img class="rotate" src="/images/home/swagger.png" alt="OpenAPI logo">
@@ -97,7 +97,7 @@
 
 				  <!-- <p><a class="btn btn-embossed btn-primary view" role="button">View Details</a></p> -->
 				</div><!-- /.col-lg-4 -->
-				
+
 				<div class="col-sm-4 wow fadeInDown text-center">
                    <span class="fa-stack fa-lg my-fa-icon-group rotate">
                      <i class="fa fa-circle-thin fa-stack-1x my-fa-icon-circle" style="color: #e0e0e0"></i>
@@ -108,7 +108,7 @@
                    <p class="lead">Document multiple API specifications as a suite of products,
                    and cross-reference as required.</p>
 				</div>
-				
+
 				<div class="col-sm-4 wow fadeInDown text-center">
                    <span class="fa-stack fa-lg my-fa-icon-group rotate">
                      <i class="fa fa-circle-thin fa-stack-1x my-fa-icon-circle" style="color: #e0e0e0"></i>
@@ -119,7 +119,7 @@
                    Swagger API documentation.</p>
 				</div>
 			</div>
-				
+
 			<div class="row">
 				<div class="col-sm-4  wow fadeInDown text-center">
                    <span class="fa-stack fa-lg my-fa-icon-group rotate">
@@ -131,7 +131,7 @@
                   <p class="lead">The built-in API explorer enables API experimentation from within the documentation pages,
                   and can seamlessly integrate into your authentication and API key model.</p>
 				</div><!-- /.col-lg-4 -->
-				
+
 				<div class="col-sm-4 wow fadeInDown text-center">
                    <span class="fa-stack fa-lg my-fa-icon-group rotate">
                      <i class="fa fa-circle fa-stack-1x my-fa-icon-circle" style="color: #e0e0e0;"></i>
@@ -142,7 +142,7 @@
                    <p class="lead">DapperDox can proxy your developer platform, allowing full integration of API key
                    generation and management alongside your specifications and guides.</p>
 				</div>
-				
+
 				<div class="col-sm-4 wow fadeInDown text-center">
                    <span class="fa-stack fa-lg my-fa-icon-group rotate">
                      <i class="fa fa-circle-thin fa-stack-1x my-fa-icon-circle" style="color: #e0e0e0;"></i> <!-- 6060a0 -->
@@ -152,28 +152,28 @@
 				   <h3>Multi theme</h3>
 				 <p class="lead">Change themes and present your documentation in the style you like!</p>
 				</div><!-- /.col-lg-4 -->
-				
+
 			</div><!-- /.row -->
 		</div>
 	</div>
-	
+
     <div id ="gettingstarted" class="content-section-a">
         <div class="container">
             <div class="row">
 				<div class="col-sm-6 pull-right wow">
                     <img class="img-responsive " src="/images/home/dapperdoxScreenshotRequest.png" alt="">
                 </div>
-				
+
                 <div class="col-sm-6 wow">
                     <h3 class="section-heading" style="margin-top: 0;">DapperDox use case</h3>
-                    
+
                     <p class="lead">
                     DapperDox was created by API documentation authors for one purpose:
                     to improve the quality and usability of the API documentation they were providing
                     for other developers.
                     </p>
                     <p class="lead">They needed the flexibility to structure and style the pages the way
-                    they wanted; 
+                    they wanted;
                     to be able to author readable guides and have them form part of a cohesive set of
                     documentation along with the API specifications;
                     to allow relevent documentation to be injected right into the rendered specification
@@ -184,13 +184,13 @@
                     and DapperDox does the rest.</p>
 
                      <p><a href="/docs/getting-started" class="btn btn-lg mybutton_green"><span class="network-name">Get started now!</span></a></p>
-				</div>   
+				</div>
             </div>
         </div>
         <!-- /.container -->
     </div>
 
-    
+
     <footer>
       <div class="container">
         <div class="row">
@@ -201,7 +201,7 @@
           </div>
           <div class="col-lg-4 col-md-4 col-sm-6 col-xs-6">
             <div class="valigned align-right">
-                <a href="https://github.com/zxchris/dapperdox"><i class="fa fa-github" aria-hidden="true"></i>&nbsp;<p>Open Source</p></a>
+                <a href="https://github.com/DapperDox/dapperdox"><i class="fa fa-github" aria-hidden="true"></i>&nbsp;<p>Open Source</p></a>
                 <a href="https://twitter.com/DapperDox"><i class="fa fa-twitter" aria-hidden="true"></i>&nbsp;<p>Twitter</p></a>
                 <!--
                 <a href=""><i class="fa fa-google-plus" aria-hidden="true"></i> <p>Google+</p></a>
@@ -218,7 +218,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 	<script src="js/script.js"></script>
 	<!-- Smoothscroll -->
-	<script type="text/javascript" src="js/jquery.corner.js"></script> 
+	<script type="text/javascript" src="js/jquery.corner.js"></script>
 	<script src="js/wow.min.js"></script>
 	<script>
 	 new WOW().init();


### PR DESCRIPTION
Noticed broken link to old repo. Updated to DapperDox/dapperdox assuming that where you want the github link to navigate to. 