### PR TITLE
Feature/remote spec filename

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,7 @@ func Get() (*config, error) {
 
 	cfg = &config{
 		BindAddr:         "localhost:3123",
-		SpecDir:          "spec",
+		SpecDir:          "",
 		DefaultAssetsDir: "assets",
 		LogLevel:         "info",
 		SiteURL:          "http://localhost:3123/",

--- a/handlers/specs/specs.go
+++ b/handlers/specs/specs.go
@@ -25,6 +25,11 @@ func Register(r *pat.Router) {
 
 	logger.Infof(nil, "Registering specifications")
 
+	if cfg.SpecDir == "" {
+		logger.Infof(nil, "- No local specifications to serve")
+		return
+	}
+
 	// Build a replacer to search/replace specification URLs
 	if specReplacer == nil {
 		var replacements []string

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -199,7 +199,7 @@ func LoadSpecifications(specHost string, collapse bool) error {
 		splithost := strings.Split(specHost, ":")
 		splithost[0] = "127.0.0.1"
 		specHost = strings.Join(splithost, ":")
-		logger.Tracef(nil, "Loading specifications from %s\n", specHost)
+		logger.Tracef(nil, "Serving specifications from %s\n", specHost)
 	}
 
 	for _, specLocation := range cfg.SpecFilename {
@@ -1288,6 +1288,8 @@ func CamelToKebab(s string) string {
 // -----------------------------------------------------------------------------
 
 func loadSpec(url string) (*loads.Document, error) {
+
+	logger.Infof(nil, "Importing OpenAPI specifications from %s", url)
 
 	document, err := loads.Spec(url)
 	if err != nil {


### PR DESCRIPTION
Adds support for remote specifications by specifying a URL in `-spec-filename`.