### PR TITLE
Fixes #64 by adding the shebang to shell scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,2 @@
+#!/usr/bin/env bash
 go build -ldflags "-s"

--- a/createReleaseTable.sh
+++ b/createReleaseTable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERSION=$1
 

--- a/run_example.sh
+++ b/run_example.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ./dapperdox \
     -spec-dir=examples/specifications/petstore/ \
     -bind-addr=0.0.0.0:3123 \

--- a/run_metadata.sh
+++ b/run_metadata.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #./dapperdox -swagger-dir=../developer.ch.gov.uk-poc/swagger -bind-addr=192.168.56.2:3123 -rewrite-url=http://localhost:4242/swagger-2.0 -site-url=http://192.168.56.2:3123 -log-level=trace
     #-swagger-dir=../../companieshouse/developer.ch.gov.uk-poc/swagger \
 ./dapperdox \


### PR DESCRIPTION
Added to those that were missing it and updated the one that had it to be the same as the others.

I used to use `#!/bin/bash/` but then someone told me I should be using `#!/usr/bin/env bash` because it's more portable. Hope that's ok.