### PR TITLE
Makes DapperDox compatible with the current version of unrolled/render

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -163,8 +163,9 @@ func overlay(name string, data []interface{}) template.HTML { // TODO Will be sp
 		logger.Tracef(nil, "Applying overlay '%s'\n", overlay)
 		writer := HTMLWriter{h: bufio.NewWriter(&b)}
 
+		r := New()
 		// data is a single item array (though I've not figured out why yet!)
-		Render.HTML(writer, http.StatusOK, overlay, data[0], render.HTMLOptions{Layout: ""})
+		r.HTML(writer, http.StatusOK, overlay, data[0], render.HTMLOptions{Layout: ""})
 		writer.Flush()
 	}
 


### PR DESCRIPTION
This fix resolves an issue #40 (deadlock due to recursive call to Render.HTML) by creating a new instance of the render for each overlay. I'm not sure it's the best approach but I had tested it on a few overlays, and it seems to be working.