### PR TITLE
Add option to read swagger spec directly from URL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2016-2017 dapperdox.com 
+Copyright (C) 2016-2017 dapperdox.com
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -30,6 +30,7 @@ type config struct {
 	BindAddr           string      `env:"BIND_ADDR" flag:"bind-addr" flagDesc:"Bind address"`
 	AssetsDir          string      `env:"ASSETS_DIR" flag:"assets-dir" flagDesc:"Assets to serve. Effectively the document root."`
 	DefaultAssetsDir   string      `env:"DEFAULT_ASSETS_DIR" flag:"default-assets-dir" flagDesc:"Default assets."`
+	SpecURL            string      `env:"SPEC_URL" flag:"spec-url" flagDesc:"OpenAPI specification (swagger) server url"`
 	SpecDir            string      `env:"SPEC_DIR" flag:"spec-dir" flagDesc:"OpenAPI specification (swagger) directory"`
 	SpecFilename       []string    `env:"SPEC_FILENAME" flag:"spec-filename" flagDesc:"The filename of the OpenAPI specification file within the spec-dir. May be multiply defined. Defaults to spec/swagger.json"`
 	Theme              string      `env:"THEME" flag:"theme" flagDesc:"Theme to render documentation"`
@@ -56,6 +57,7 @@ func Get() (*config, error) {
 	cfg = &config{
 		BindAddr:         "localhost:3123",
 		SpecDir:          "",
+		SpecURL:          "",
 		DefaultAssetsDir: "assets",
 		LogLevel:         "info",
 		SiteURL:          "http://localhost:3123/",

--- a/main.go
+++ b/main.go
@@ -94,7 +94,11 @@ func main() {
 	specs.Register(router)
 	spec.LoadStatusCodes()
 
-	err = spec.LoadSpecifications(cfg.BindAddr, true)
+	if cfg.SpecURL != "" {
+		err = spec.LoadSpecification(cfg.SpecURL)
+	} else {
+		err = spec.LoadSpecifications(cfg.BindAddr, true)
+	}
 	if err != nil {
 		logger.Errorf(nil, "Load specification error: %s", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -94,11 +94,7 @@ func main() {
 	specs.Register(router)
 	spec.LoadStatusCodes()
 
-	if cfg.SpecURL != "" {
-		err = spec.LoadSpecification(cfg.SpecURL)
-	} else {
-		err = spec.LoadSpecifications(cfg.BindAddr, true)
-	}
+	err = spec.LoadSpecifications(cfg.BindAddr, true)
 	if err != nil {
 		logger.Errorf(nil, "Load specification error: %s", err)
 		os.Exit(1)

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -293,6 +293,28 @@ func LoadSpecifications(specHost string, collapse bool) error {
 	return nil
 }
 
+func LoadSpecification(specUrl string) error {
+	if APISuite == nil {
+		APISuite = make(map[string]*APISpecification)
+	}
+
+	var ok bool
+	var specification *APISpecification
+
+	if specification, ok = APISuite[""]; !ok {
+		specification = &APISpecification{}
+	}
+
+	var err = specification.Load(specUrl, "")
+	if err != nil {
+		return err
+	}
+
+	APISuite[specification.ID] = specification
+
+	return nil
+}
+
 // -----------------------------------------------------------------------------
 // Load loads API specs from the supplied host (usually local!)
 func (c *APISpecification) Load(specLocation string, specHost string) error {
@@ -386,10 +408,10 @@ func (c *APISpecification) Load(specLocation string, specHost string) error {
 		// If we're grouping by TAGs, then build the API at the tag level
 		if groupingByTag {
 			api = &APIGroup{
-				ID:   TitleToKebab(name),
-				Name: name,
-				URL:  u,
-				Info: &c.APIInfo,
+				ID:                     TitleToKebab(name),
+				Name:                   name,
+				URL:                    u,
+				Info:                   &c.APIInfo,
 				MethodNavigationByName: methodNavByName,
 				MethodSortBy:           methodSortBy,
 				Consumes:               apispec.Consumes,
@@ -407,10 +429,10 @@ func (c *APISpecification) Load(specLocation string, specHost string) error {
 			// If not grouping by tag, then build the API at the path level
 			if !groupingByTag {
 				api = &APIGroup{
-					ID:   TitleToKebab(name),
-					Name: name,
-					URL:  u,
-					Info: &c.APIInfo,
+					ID:                     TitleToKebab(name),
+					Name:                   name,
+					URL:                    u,
+					Info:                   &c.APIInfo,
 					MethodNavigationByName: methodNavByName,
 					MethodSortBy:           methodSortBy,
 					Consumes:               apispec.Consumes,


### PR DESCRIPTION
Springfox swagger does generation of swagger.json at runtime, because of that we need to run app to get that file and refresh DapperDox. With this simple param, DapperDox will receive fresh swagger spec directly from the service running with springfox.