### PR TITLE
Performance fix for issue with GFM replacements slice growing for every call to asset.CompileGFMMap

### DIFF
--- a/render/asset/asset.go
+++ b/render/asset/asset.go
@@ -348,6 +348,9 @@ func CompileGFMMap() {
 
 	scanner := bufio.NewScanner(file)
 
+	// Reset to stop replacement list being duplicated for every call to this function
+	gfmReplace = gfmReplace[:0]
+	
 	for scanner.Scan() {
 		line := scanner.Text()
 


### PR DESCRIPTION
The replacement maps for use with GFM were being appended to the gfmReplace slice every request (every call to asset.CompileGFMMap), and so the list of replacements was being repeatedly duplicated as gfmReplace is shared.  This resulted in an ever-increasing number of replacements being run in the function asset.ProcessMarkdown.

This change is to build the list of replacements only once in asset.CompileGFMMap and avoid repeating that work for future calls.
